### PR TITLE
Use done() instead of then()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -6,6 +6,7 @@ use React\Promise\PromiseInterface;
 use Rx\Observable;
 use Rx\ObserverInterface;
 use Rx\SchedulerInterface;
+use function React\Promise\resolve;
 
 /**
  * Take an observable from a promise and return an new observable piping through the stream.
@@ -20,7 +21,7 @@ function unwrapObservableFromPromise(PromiseInterface $promise): Observable
             ObserverInterface $observer,
             SchedulerInterface $scheduler
         ) use ($promise) {
-            $promise->then(function (Observable $observable) use ($observer, $scheduler) {
+            resolve($promise)->done(function (Observable $observable) use ($observer, $scheduler) {
                 $observable->subscribeCallback(
                     function ($next) use ($observer) {
                         $observer->onNext($next);

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -63,4 +63,20 @@ final class FunctionsTest extends TestCase
         self::assertFalse($completed);
         self::assertSame($exception, $currentException);
     }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testUnwrapObservableFromPromiseDoesNotSwallowException()
+    {
+        unwrapObservableFromPromise(
+            resolve(
+                Observable::just(1)
+            )
+        )->subscribeCallback(
+            function () {
+                throw new Exception('boom');
+            }
+        );
+    }
 }


### PR DESCRIPTION
When not returning a promise, done() should be used to not swallow exceptions thrown inside the callbacks.
Also, done() does not create unused child promises, saving a bit of resources.

Passing `$promise` through `resolve()` makes extra sure we're working on `ExtendedPromiseInterface`. Theoretically, this could be ommitted since all promises from react/promise implementing `PromiseInterface` also implement `ExtendedPromiseInterface` (applies to react/promise 2.x).